### PR TITLE
Add missing implementation of LOCAL-ADDR for CCL

### DIFF
--- a/swank/ccl.lisp
+++ b/swank/ccl.lisp
@@ -102,6 +102,13 @@
                    :local-host host :reuse-address t
                    :backlog (or backlog 5)))
 
+(defimplementation local-addr (socket)
+  (let* ((u32ip (ccl:local-host socket))
+         (a (ldb (byte 8 24) u32ip))
+         (b (ldb (byte 8 16) u32ip))
+         (c (ldb (byte 8  8) u32ip))
+         (d (ldb (byte 8  0) u32ip)))
+    (coerce (list a b c d) 'simple-array)))
 (defimplementation local-port (socket)
   (ccl:local-port socket))
 


### PR DESCRIPTION
Previously, starting up a Swank server on CCL would jump you into the
debugger:

    > Error: SWANK/BACKEND:LOCAL-ADDR not implemented
    > While executing: SWANK/BACKEND:LOCAL-ADDR, in process listener(1).
    > Type :GO to continue, :POP to abort, :R for a list of available restarts.
    > If continued: Skip loading "/Users/matteolandi/.lisp/vlime-lswank.lisp"
    > Type :? for other options.

This commit adds the missing implementation, and with this, it's
possible to start a Swank server on CCL just fine.