### PR TITLE
SBCL: implement THREAD-ATTRIBUTES only for Linux

### DIFF
--- a/contrib/swank-fuzzy.lisp
+++ b/contrib/swank-fuzzy.lisp
@@ -74,7 +74,9 @@ designator's format. The cases are as follows:
                               (zerop time-limit-in-msec)))
          (time-limit (if no-time-limit-p nil time-limit-in-msec)))
     (multiple-value-bind (completion-set interrupted-p)
-        (fuzzy-completion-set string default-package-name :limit limit
+        ;; Deep down there's a type SIMPLE-STRING required...
+        (fuzzy-completion-set (coerce string 'simple-string)
+                              default-package-name :limit limit
                               :time-limit-in-msec time-limit)
       ;; We may send this as elisp [] arrays to spare a coerce here,
       ;; but then the network serialization were slower by handling arrays.

--- a/packages.lisp
+++ b/packages.lisp
@@ -164,6 +164,7 @@
            #:*swank-pprint-bindings*
            #:*record-repl-results*
            #:*inspector-verbose*
+           #:on-inspect-bind-to
            ;; This is SETFable.
            #:debug-on-swank-error
            ;; These are re-exported directly from the backend:

--- a/swank.lisp
+++ b/swank.lisp
@@ -721,11 +721,11 @@ If PACKAGE is not specified, the home package of SYMBOL is used."
 
 (defun start-server (port-file &key (style *communication-style*)
                                     (dont-close *dont-close*))
-  "Start the server and write the listen port number to PORT-FILE.
+  "Start the server and write the listen address and port number to PORT-FILE.
 This is the entry point for Emacs."
   (setup-server (or (ignore-errors (parse-integer (sb-posix:getenv "JS_SWANK_PORT")))
                     0)
-                (lambda (port) (announce-server-port port-file port))
+                (lambda (addr port) (announce-server-port port-file addr port))
                 style dont-close nil))
 
 (defun create-server (&key (port default-server-port)
@@ -766,10 +766,15 @@ e.g.: (restart-loop (http-request url) (use-value (new) (setq url new)))"
         (ignore-errors (list (parse-integer (read-line *query-io*)))))
       (setq port new-port))))
 
+(defun octets-to-ip-string (addr)
+  (ecase (length addr)
+    (4 (format nil "~{~d~^.~}" (coerce addr 'list)))
+    (16 (format nil "~{~2,'0x~2,'0x~^:~}" (coerce addr 'list)))))
+
 (defun setup-server (port announce-fn style dont-close backlog)
   (init-log-output)
   (let* ((socket (socket-quest port backlog))
-         (addr (local-addr socket))
+         (addr (octets-to-ip-string (local-addr socket)))
          (port (local-port socket)))
     (funcall announce-fn addr port)
     (labels ((serve () (accept-connections socket style dont-close))

--- a/swank.lisp
+++ b/swank.lisp
@@ -769,8 +769,9 @@ e.g.: (restart-loop (http-request url) (use-value (new) (setq url new)))"
 (defun setup-server (port announce-fn style dont-close backlog)
   (init-log-output)
   (let* ((socket (socket-quest port backlog))
+         (addr (local-addr socket))
          (port (local-port socket)))
-    (funcall announce-fn port)
+    (funcall announce-fn addr port)
     (labels ((serve () (accept-connections socket style dont-close))
              (note () (send-to-sentinel `(:add-server ,socket ,port
                                                       ,(current-thread))))
@@ -848,17 +849,17 @@ if the file doesn't exist; otherwise the first line of the file."
        (:sigio (deinstall-sigio-handler connection))
        (:fd-handler (deinstall-fd-handler connection))))))
 
-(defun announce-server-port (file port)
+(defun announce-server-port (file address port)
   (with-open-file (s file
                      :direction :output
                      :if-exists :error
                      :if-does-not-exist :create)
-    (format s "~S~%" port))
-  (simple-announce-function port))
+    (format s "~S ~S~%" address port))
+  (simple-announce-function address port))
 
-(defun simple-announce-function (port)
+(defun simple-announce-function (address port)
   (when *swank-debug-p*
-    (format *log-output* "~&;; Swank started at port: ~D.~%" port)
+    (format *log-output* "~&;; Swank started at ~a, port: ~D.~%" address port)
     (force-output *log-output*)))
 
 

--- a/swank.lisp
+++ b/swank.lisp
@@ -723,8 +723,7 @@ If PACKAGE is not specified, the home package of SYMBOL is used."
                                     (dont-close *dont-close*))
   "Start the server and write the listen address and port number to PORT-FILE.
 This is the entry point for Emacs."
-  (setup-server (or (ignore-errors (parse-integer (sb-posix:getenv "JS_SWANK_PORT")))
-                    0)
+  (setup-server 0
                 (lambda (addr port) (announce-server-port port-file addr port))
                 style dont-close nil))
 

--- a/swank.lisp
+++ b/swank.lisp
@@ -1103,7 +1103,7 @@ The processing is done in the extent of the toplevel restart."
 
 (defun wait-for-event (pattern &optional timeout)
   "Scan the event queue for PATTERN and return the event.
-If TIMEOUT is 'nil wait until a matching event is enqued.
+If TIMEOUT is 'nil wait until a matching event is enqueued.
 If TIMEOUT is 't only scan the queue without waiting.
 The second return value is t if the timeout expired before a matching
 event was found."
@@ -2101,7 +2101,7 @@ after Emacs causes a restart to be invoked."
   "The initial number of backtrace frames to send to Emacs.")
 
 (defvar *sldb-restarts* nil
-  "The list of currenlty active restarts.")
+  "The list of currently active restarts.")
 
 (defvar *sldb-stepping-p* nil
   "True during execution of a step command.")
@@ -2243,7 +2243,7 @@ where
   restart     ::= (name description)
   stack-frame ::= (number description [plist])
   extra       ::= (:references and other random things)
-  cont        ::= continutation
+  cont        ::= continuation
   plist       ::= (:restartable {nil | t | :unknown})
 
 condition---a pair of strings: message, and type.  If show-source is
@@ -2254,7 +2254,7 @@ restart---a pair of strings: restart name, and description.
 stack-frame---a number from zero (the top), and a printed
 representation of the frame's call.
 
-continutation---the id of a pending Emacs continuation.
+continuation---the id of a pending Emacs continuation.
 
 Below is an example return value. In this case the condition was a
 division by zero (multi-line description), and only one frame is being

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -218,6 +218,9 @@
 (defimplementation create-socket (host port &key backlog)
   (ext:make-server-socket port))
 
+(defimplementation local-address (socket)
+  (jcall (jmethod "java.net.ServerSocket" "getLocalAddress") socket)) ;; ??
+
 (defimplementation local-port (socket)
   (jcall (jmethod "java.net.ServerSocket" "getLocalPort") socket))
 

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -1008,7 +1008,7 @@
       (when (atom what)
         (setq what (list what sym)))
       (list (definition-specifier what)
-            (if (ext:pathname-jar-p path2)
+            (if (ext:pathname-jar-p (pathname path2))
                 `(:location
                   (:zip ,@(split-string (subseq path2 (length "jar:file:")) "!/"))
                   ;; pos never seems right. Use function name.

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -342,6 +342,9 @@ form suitable for testing with #+."
   "Create a listening TCP socket on interface HOST and port PORT.
 BACKLOG queue length for incoming connections.")
 
+(definterface local-addr (socket)
+  "Return the local address used by SOCKET.")
+
 (definterface local-port (socket)
   "Return the local port number of SOCKET.")
 

--- a/swank/ccl.lisp
+++ b/swank/ccl.lisp
@@ -102,6 +102,13 @@
                    :local-host host :reuse-address t
                    :backlog (or backlog 5)))
 
+(defimplementation local-addr (socket)
+  (let* ((u32ip (ccl:local-host socket))
+         (a (ldb (byte 8 24) u32ip))
+         (b (ldb (byte 8 16) u32ip))
+         (c (ldb (byte 8  8) u32ip))
+         (d (ldb (byte 8  0) u32ip)))
+    (coerce (list a b c d) 'simple-array)))
 (defimplementation local-port (socket)
   (ccl:local-port socket))
 

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -172,7 +172,7 @@
   (namestring (ext:getcwd)))
 
 (defimplementation quit-lisp ()
-  (core:quit))
+  (sys:quit))
 
 
 
@@ -236,9 +236,9 @@
   ;; due to the :source-debug parameters from
   ;; swank-compile-string (below).
   (make-file-location
-   (core:file-scope-pathname
-    (core:file-scope origin))
-   (core:source-pos-info-filepos origin)))
+   (sys:file-scope-pathname
+    (sys:file-scope origin))
+   (sys:source-pos-info-filepos origin)))
 
 (defun condition-location (origin)
   (typecase origin
@@ -327,7 +327,7 @@
 
 (defimplementation arglist (name)
   (multiple-value-bind (arglist foundp)
-      (core:function-lambda-list name)     ;; Uses bc-split
+      (sys:function-lambda-list name)     ;; Uses bc-split
     (if foundp arglist :not-available)))
 
 (defimplementation function-name (f)
@@ -356,7 +356,7 @@
                 nil)
                ((macro-function (car form) environment)
                 (push form macro-forms))
-               ((not (eq form (core:compiler-macroexpand-1 form environment)))
+               ((not (eq form (sys:compiler-macroexpand-1 form environment)))
                 (push form compiler-macro-forms))))
        form)
      form environment)
@@ -708,18 +708,18 @@
            (slime-dbg "receive-if condition-variable-timedwait")
            (mp:condition-variable-wait (mailbox.cvar mbox) mutex) ; timedwait 0.2
            (slime-dbg "came out of condition-variable-timedwait")
-           (core:check-pending-interrupts)))))
+           (sys:check-pending-interrupts)))))
 
   ) ; #+threads (progn ...
 
 
-(defmethod emacs-inspect ((object core:cxx-object))
-  (let ((encoded (core:encode object)))
+(defmethod emacs-inspect ((object sys:cxx-object))
+  (let ((encoded (sys:encode object)))
     (loop for (key . value) in encoded
        append (list (string key) ": " (list :value value) (list :newline)))))
 
-(defmethod emacs-inspect ((object core:va-list))
-  (emacs-inspect (core:list-from-va-list object)))
+(defmethod emacs-inspect ((object sys:vaslist))
+  (emacs-inspect (sys:list-from-vaslist object)))
 
 ;;; Packages
 

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -71,6 +71,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/cmucl.lisp
+++ b/swank/cmucl.lisp
@@ -67,6 +67,8 @@
   (declare (ignore host))
   (ext:create-inet-listener port :stream :reuse-address t))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (ext::get-socket-host-and-port (socket-fd socket))))
 (defimplementation local-port (socket)
   (nth-value 1 (ext::get-socket-host-and-port (socket-fd socket))))
 

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -84,6 +84,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/lispworks.lisp
+++ b/swank/lispworks.lisp
@@ -99,6 +99,8 @@
                                       (list #+unix (lw:get-unix-error errno))
                                       errno))))))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (comm:get-socket-address (socket-fd socket))))
 (defimplementation local-port (socket)
   (nth-value 1 (comm:get-socket-address (socket-fd socket))))
 

--- a/swank/mkcl.lisp
+++ b/swank/mkcl.lisp
@@ -63,6 +63,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/rpc.lisp
+++ b/swank/rpc.lisp
@@ -8,7 +8,7 @@
 ;;; are disclaimed.
 ;;;
 
-(in-package swank/rpc)
+(in-package :swank/rpc)
 
 
 ;;;;; Input

--- a/swank/rpc.lisp
+++ b/swank/rpc.lisp
@@ -106,7 +106,7 @@
     (write-sequence octets stream)
     (finish-output stream)))
 
-;; FIXME: for now just tell emacs that we and an encoding problem.
+;; FIXME: for now just tell emacs that we had an encoding problem.
 (defun encoding-error (condition string)
   (swank/backend:string-to-utf8
    (prin1-to-string-for-emacs

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -131,6 +131,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1712,6 +1712,16 @@ stack."
     ;; sometimes the name is not a string (e.g. NIL)
     (princ-to-string (sb-thread:thread-name thread)))
 
+  (defimplementation thread-attributes (thread)
+    (let* ((tid (sb-thread:thread-os-tid thread))
+           (cpu-time
+             (ignore-errors
+               (with-open-file (s (format nil "/proc/self/task/~d/schedstat" tid))
+                 (* (parse-integer (read-line s nil nil) :junk-allowed t)
+                    1d-9)))))
+      (list :tid (sb-thread:thread-os-tid thread)
+            :cpu-secs (format nil "~,3f" cpu-time))))
+
   (defimplementation thread-status (thread)
     (if (sb-thread:thread-alive-p thread)
         "Running"

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1712,10 +1712,10 @@ stack."
     ;; sometimes the name is not a string (e.g. NIL)
     (princ-to-string (sb-thread:thread-name thread)))
 
+  #+linux
   (defimplementation thread-attributes (thread)
     (let* ((tid (sb-thread:thread-os-tid thread))
            (cpu-time
-             #+linux
              (ignore-errors
                (with-open-file (s (format nil "/proc/self/task/~d/schedstat" tid))
                  (* (parse-integer (read-line s nil nil) :junk-allowed t)

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1722,7 +1722,7 @@ stack."
                     1d-9)))))
       (list* :tid (sb-thread:thread-os-tid thread)
              (when cpu-time
-               `(:cpu-secs (format nil "~,3f" cpu-time))))))
+               `(:cpu-secs ,(format nil "~,3f" cpu-time))))))
 
   (defimplementation thread-status (thread)
     (if (sb-thread:thread-alive-p thread)

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1715,12 +1715,14 @@ stack."
   (defimplementation thread-attributes (thread)
     (let* ((tid (sb-thread:thread-os-tid thread))
            (cpu-time
+             #+linux
              (ignore-errors
                (with-open-file (s (format nil "/proc/self/task/~d/schedstat" tid))
                  (* (parse-integer (read-line s nil nil) :junk-allowed t)
                     1d-9)))))
-      (list :tid (sb-thread:thread-os-tid thread)
-            :cpu-secs (format nil "~,3f" cpu-time))))
+      (list* :tid (sb-thread:thread-os-tid thread)
+             (when cpu-time
+               `(:cpu-secs (format nil "~,3f" cpu-time))))))
 
   (defimplementation thread-status (thread)
     (if (sb-thread:thread-alive-p thread)

--- a/swank/scl.lisp
+++ b/swank/scl.lisp
@@ -34,6 +34,8 @@
     (ext:create-inet-listener port :stream :host addr :reuse-address t
                               :backlog (or backlog 5))))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (ext::get-socket-host-and-port (socket-fd socket))))
 (defimplementation local-port (socket)
   (nth-value 1 (ext::get-socket-host-and-port (socket-fd socket))))
 


### PR DESCRIPTION
SBCL defines SB-THREAD:THREAD-OS-TID only for Linux, and accessing it
from MacOS or Windows will result in a symbol not found error:

    ; caught ERROR:
    ;   READ error during COMPILE-FILE:
    ;
    ;     Symbol "THREAD-OS-TID" not found in the SB-THREAD package.
    ;
    ;       Line: 1716, Column: 40, File-Position: 69208
    ;
    ;       Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /Users/matteolandi/my-env/opt/slime/swank/sbcl.lisp" {1001ECFC23}>
    ;;
    ;; Error compiling /Users/matteolandi/my-env/opt/slime/swank/sbcl.lisp:
    ;;   COMPILE-FILE returned NIL.
    ;;